### PR TITLE
feat: FactoryBot (former FactoryGirl)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ group :development, :test do
   gem "debug", platforms: %i[ mri windows ]
   gem 'rspec-rails', '~> 6.1.0'
   gem 'capybara'
+  gem 'factory_bot_rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,11 @@ GEM
     diff-lcs (1.5.1)
     drb (2.2.1)
     erubi (1.12.0)
+    factory_bot (6.4.6)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.4.3)
+      factory_bot (~> 6.4)
+      railties (>= 5.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.1)
@@ -271,6 +276,7 @@ DEPENDENCIES
   bootsnap
   capybara
   debug
+  factory_bot_rails
   importmap-rails
   jbuilder
   puma (>= 5.0)

--- a/spec/factories/customer.rb
+++ b/spec/factories/customer.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :customer do
+    name {"Beatriz"}
+    email {"beatriz@filha.com"}
+  end
+end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -2,16 +2,25 @@ require 'rails_helper'
 
 RSpec.describe Customer, type: :model do
 
-  fixtures :customers #ou fixtures :all
+# Creating using features
+#   fixtures :customers #ou fixtures :all
     
-    # subject.name = "Vanderlei Pinto"
-    # subject.email = "vandecopinto@gmail.com"
-    # subject.save
+#     # subject.name = "Vanderlei Pinto"
+#     # subject.email = "vandecopinto@gmail.com"
+#     # subject.save
+
+#   it 'Create a Customer' do 
+#     customer = customers(:vanderlei)
+
+#     expect(customer.name).to eq("Vanderlei Pinto")
+#     expect(customer.full_name).to eq("Sr. Vanderlei Pinto")
+#   end
+
+#  Creating using factory bot
 
   it 'Create a Customer' do 
-    customer = customers(:vanderlei)
+    customer = build (:customer)
+    expect(customer.full_name).to eq("Sr. Beatriz")
+  end    
 
-    expect(customer.name).to eq("Vanderlei Pinto")
-    expect(customer.full_name).to eq("Sr. Vanderlei Pinto")
-  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -35,6 +35,9 @@ RSpec.configure do |config|
     Rails.root.join('spec/fixtures')
   ]
 
+  #FactoryBot  
+    config.include FactoryBot::Syntax::Methods  
+
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.


### PR DESCRIPTION
### Instalando o FactoryBot Rails.

Adicionar a gem no arquivo Gemfile:

```ruby
group :development, :test do
  gem 'factory_bot_rails'
end
``` 

Fazer a configuração no spec/rails_helper.rb

```ruby
...
RSpec.configure do |config|
... 
    config.include FactoryBot::Syntax::Methods
...
end
``` 
### Como usar?

Criar o aquivo spec/factories/customer.rb e definir o formato.

```ruby
FactoryBot.define do
  factory :customer do
    name {"Beatriz"}
    email {"beatriz@filha.com"}
  end
end
``` 

OBS: Ao contrário do que é passado na aula, na nova atualização fica name {"Beatriz"} ao invés de name "Beatriz"

Usaremos o factory no arquivo spec/models/customer_spec.rb usando o comando create ou build. A diferença é que o create salva o objeto já o build só cria o objeto e não salva.

```ruby
require 'rails_helper'
 
RSpec.describe Customer, type: :model do
  it 'Create a Customer' do 
    customer = build (:customer)
    expect(customer.full_name).to eq("Sr. Beatriz")
  end    
 
end
``` 
