### PR TITLE
feat: Gem Faker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ group :development, :test do
   gem 'rspec-rails', '~> 6.1.0'
   gem 'capybara'
   gem 'factory_bot_rails'
+  gem 'faker'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,8 @@ GEM
     factory_bot_rails (6.4.3)
       factory_bot (~> 6.4)
       railties (>= 5.0.0)
+    faker (3.2.3)
+      i18n (>= 1.8.11, < 2)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.1)
@@ -277,6 +279,7 @@ DEPENDENCIES
   capybara
   debug
   factory_bot_rails
+  faker
   importmap-rails
   jbuilder
   puma (>= 5.0)

--- a/spec/factories/customer.rb
+++ b/spec/factories/customer.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :customer do
-    name {"Beatriz"}
+    name {Faker::Name.name}
     email {"beatriz@filha.com"}
   end
 end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -18,9 +18,12 @@ RSpec.describe Customer, type: :model do
 
 #  Creating using factory bot
 
-  it 'Create a Customer' do 
+  it 'Full name' do 
     customer = build (:customer)
-    expect(customer.full_name).to eq("Sr. Beatriz")
+    expect(customer.full_name).to start_with("Sr")    
   end    
+
+  it {expect{ create(:customer)}.to change {Customer.all.size}.by(1)}
+  # Vai criar o cliente e vai verificar que um registro foi incrementado.
 
 end


### PR DESCRIPTION
### Gem Faker

Gem para gerar dados falsos.

###Instalação Gemfile
```ruby
group :development, :test do
...
`gem 'faker'`
...
end
``` 

`bundle`

### Usando a gem faker

No arquivo spec/factories/customer.rb fazemos com que o faker crie o nome e o email.

```ruby
FactoryBot.define do
  factory :customer do
    name {Faker::Name.name}
    email {"Faker::Email.email"}
  end
end
``` 

### Testando 

```ruby
require 'rails_helper'

RSpec.describe Customer, type: :model do
  it 'Full name' do 
    customer = build (:customer)
    expect(customer.full_name).to start_with("Sr")    
  end    
  it {expect{ create(:customer)}.to change {Customer.all.size}.by(1)}
  # Vai criar o cliente e vai verificar se um registro foi incrementado.
end
``` 

