### PR TITLE
feat: Sobrescrevendo atributos e Aliases para fabricas

### DIFF
--- a/spec/factories/customer.rb
+++ b/spec/factories/customer.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :customer do
+  factory :customer, aliases: [:user, :worker] do
     name {Faker::Name.name}
     email {"beatriz@filha.com"}
   end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Customer, type: :model do
 
-# Creating using features
+#### Creating using features --------------------------
 #   fixtures :customers #ou fixtures :all
     
 #     # subject.name = "Vanderlei Pinto"
@@ -16,14 +16,19 @@ RSpec.describe Customer, type: :model do
 #     expect(customer.full_name).to eq("Sr. Vanderlei Pinto")
 #   end
 
-#  Creating using factory bot
+####  Creating using factory bot -------------------------
 
-  it 'Full name' do 
-    customer = build (:customer)
-    expect(customer.full_name).to start_with("Sr")    
-  end    
+  # it 'Full name' do 
+  #   customer = build (:customer)
+  #   expect(customer.full_name).to start_with("Sr")    
+  # end    
 
-  it {expect{ create(:customer)}.to change {Customer.all.size}.by(1)}
-  # Vai criar o cliente e vai verificar que um registro foi incrementado.
+  # it {expect{ create(:customer)}.to change {Customer.all.size}.by(1)}
+  # # Vai criar o cliente e vai verificar que um registro foi incrementado.
 
+  it 'full_name_ Sobrescrevendo atributo' do
+    customer = build(:worker, name: "Vanderlei Pinto") ##ou :customer, :worker ou :user
+    expect(customer.full_name).to eq("Sr. Vanderlei Pinto")
+  end
+    
 end


### PR DESCRIPTION
### Sobrescrevendo um atributo

Faz-se a criação do objeto normalmente e sobrescreve os dados desejados:

```ruby
require 'rails_helper'
 
RSpec.describe Customer, type: :model do
  it 'full_name_ Sobrescrevendo atributo' do
    customer = create(:customer, name: "Vanderlei Pinto") #sobrescreve o nome
    expect(customer.full_name).to eq("Sr. Vanderlei Pinto")
  end    
end
``` 

### Aliases

Podemos usar o aliases para dar um 'apelido' para o factory.

No arquivo spec/factories/customer.rb

```ruby
FactoryBot.define do
  factory :customer, aliases: [:user, :worker] do #apelidos para customer
    name {Faker::Name.name}
    email {"beatriz@filha.com"}
  end
end

``` 

No teste podemos usar: :customer, :worker ou :user

```ruby
customer = build(:worker, name: "Vanderlei") #ou :customer, :worker ou :user
``` 

