### PR TITLE
feat: Heranca

### DIFF
--- a/db/migrate/20240301131925_create_customers.rb
+++ b/db/migrate/20240301131925_create_customers.rb
@@ -3,6 +3,8 @@ class CreateCustomers < ActiveRecord::Migration[7.1]
     create_table :customers do |t|
       t.string :name
       t.string :email
+      t.boolean :vip
+      t.integer :days_to_pay
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,6 +14,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_01_131925) do
   create_table "customers", force: :cascade do |t|
     t.string "name"
     t.string "email"
+    t.boolean "vip"
+    t.integer "days_to_pay"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/factories/customer.rb
+++ b/spec/factories/customer.rb
@@ -2,5 +2,15 @@ FactoryBot.define do
   factory :customer, aliases: [:user, :worker] do
     name {Faker::Name.name}
     email {"beatriz@filha.com"}
+    
+    factory :customer_vip do
+      vip {true}
+      days_to_pay {30}
+    end
+
+    factory :customer_default do
+      vip {false}
+      days_to_pay {15}
+    end
   end
 end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Customer, type: :model do
 
+ 
 #### Creating using features --------------------------
 #   fixtures :customers #ou fixtures :all
     
@@ -26,9 +27,15 @@ RSpec.describe Customer, type: :model do
   # it {expect{ create(:customer)}.to change {Customer.all.size}.by(1)}
   # # Vai criar o cliente e vai verificar que um registro foi incrementado.
 
-  it 'full_name_ Sobrescrevendo atributo' do
-    customer = build(:worker, name: "Vanderlei Pinto") ##ou :customer, :worker ou :user
-    expect(customer.full_name).to eq("Sr. Vanderlei Pinto")
-  end
-    
+# ### Sobrescrevendo atributo e Criando Aliases  
+#   it 'full_name_ Sobrescrevendo atributo' do
+#     customer = build(:worker, name: "Vanderlei Pinto") ##ou :customer, :worker ou :user de acordo com o que foi definido em factory
+#     expect(customer.full_name).to eq("Sr. Vanderlei Pinto")
+#   end
+
+### Usando herança
+  it 'Herança' do
+    customer = create(:customer_vip) #herança criada na factory
+    expect(customer.vip).to eq(true)
+   end
 end


### PR DESCRIPTION
Para esse exemplo vamos alterar o banco de dados usando o arquivo db/migrate/20240301131925_create_customers.rb
```ruby
class CreateCustomers < ActiveRecord::Migration[7.1]
  def change
    create_table :customers do |t|
      t.string :name
      t.string :email
      t.boolean :vip
      t.integer :days_to_pay
 
      t.timestamps
    end
  end
end
``` 

Após essa alteração vamos apagar e recriar o banco de dados:

`rails db:drop db:create db:migrate`

### Alterando o Factory
Alterando a factory para o model alterado:

```ruby
FactoryBot.define do
  factory :customer, aliases: [:user, :worker] do
    name {Faker::Name.name}
    email {"beatriz@filha.com"}
    vip {true}
    days_to_pay {30}
  end
end
``` 
Agora podemos fazer o teste do novo model

```ruby
require 'rails_helper'
 
RSpec.describe Customer, type: :model do
   it '#full_name' do
    customer = create(:customer, vip: false, days_to_pay: 10) 
    expect(customer.vip).to be_falsey
  end
end
``` 
Ou seja, alteramos o model para conter o vip e o days_to_pay, o que é um trabalho extra.
Podemos usar então a herança para não ter que ficar alterando o model em todos os testes.

No arquivo spec/factories/customer.rb

```ruby
FactoryBot.define do
  factory :customer, aliases: [:user, :worker] do
    name {Faker::Name.name}
    email {"beatriz@filha.com"}
    
    factory :customer_vip do
      vip {true}
      days_to_pay {30}
    end
 
    factory :customer_default do
      vip {false}
      days_to_pay {15}
    end
  end
end
``` 
Agora para fazer o teste fica da seguinte maneira:spec/models/customer_spec.rb

```ruby
require 'rails_helper'
 
RSpec.describe Customer, type: :model do
  it '#full_name herança' do
    customer = create(:customer_vip) #usando a herança
    expect(customer.vip).to eq(true)
  end
end
``` 
Se utilizarmos somente o :customer, os dados de herança (vip e days_to_pay) não serão preenchidos.

