### PR TITLE
feat: attributes_for

### DIFF
--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe Customer, type: :model do
 #     # subject.email = "vandecopinto@gmail.com"
 #     # subject.save
 
-#   it 'Create a Customer' do 
-#     customer = customers(:vanderlei)
+  # it 'Create a Customer' do 
+  #   customer = create(:worker)
 
-#     expect(customer.name).to eq("Vanderlei Pinto")
-#     expect(customer.full_name).to eq("Sr. Vanderlei Pinto")
-#   end
+  #   expect(customer.name).to eq("Vanderlei Pinto")
+  #   expect(customer.full_name).to eq("Sr. Vanderlei Pinto")
+  # end
 
 ####  Creating using factory bot -------------------------
 
@@ -34,8 +34,19 @@ RSpec.describe Customer, type: :model do
 #   end
 
 ### Usando herança
-  it 'Herança' do
-    customer = create(:customer_vip) #herança criada na factory
-    expect(customer.vip).to eq(true)
-   end
+  # it 'Herança' do
+  #   customer = create(:customer_vip) #herança criada na factory
+  #   expect(customer.vip).to eq(true)
+  #  end
+
+  it 'Usando o Attributes_for' do
+    attrs = attributes_for(:customer)
+    attrs1 = attributes_for(:customer_vip)
+    attrs2 = attributes_for(:customer_default)
+    p attrs
+    p attrs1
+    p attrs2
+    customer = Customer.build(attrs)
+    expect(customer.full_name).to start_with("Sr.")
+  end
 end


### PR DESCRIPTION

Temos a possibilidade de usar o create e o build para usar o model. O create salva no BD e o build cria somente o objeto.

```ruby
customer = create(:customer) # ou
customer = build(:customer)
``` 
Mas além desses dois métodos temos o __attributes_for__ ,ele vai trazer apenas os atributos em um Hash dos elementos do model.

No teste:

```ruby
require 'rails_helper'
 
RSpec.describe Customer, type: :model do
 
 
  it 'Usando o Attributes_for' do
    attrs = attributes_for(:customer)
    attrs1 = attributes_for(:customer_vip)
    attrs2 = attributes_for(:customer_default)
    p attrs #mostra a hash de atributos
    p attrs1
    p attrs2
    customer = Customer.build(attrs) 
    expect(customer.full_name).to start_with("Sr.")
  end
end
``` 