### PR TITLE
feat: Atributos transitorios (transient)

### DIFF
--- a/spec/factories/customer.rb
+++ b/spec/factories/customer.rb
@@ -1,5 +1,11 @@
 FactoryBot.define do
   factory :customer, aliases: [:user, :worker] do
+    
+    transient do
+      upcased  {false} #valor que pode ser mudado na criação do objeto - customer = create(:customer, upcased: true)
+    end
+
+
     name {Faker::Name.name}
     email {"beatriz@filha.com"}
     
@@ -12,5 +18,10 @@ FactoryBot.define do
       vip {false}
       days_to_pay {15}
     end
+
+    after(:create) do |customer, evaluator|  #executa essa ação após criar o objeto.
+      customer.name.upcase! if evaluator.upcased #transforma em maiusculo se upcased == true
+    end
+
   end
 end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -39,14 +39,20 @@ RSpec.describe Customer, type: :model do
   #   expect(customer.vip).to eq(true)
   #  end
 
-  it 'Usando o Attributes_for' do
-    attrs = attributes_for(:customer)
-    attrs1 = attributes_for(:customer_vip)
-    attrs2 = attributes_for(:customer_default)
-    p attrs
-    p attrs1
-    p attrs2
-    customer = Customer.build(attrs)
-    expect(customer.full_name).to start_with("Sr.")
+  # it 'Usando o Attributes_for' do
+  #   attrs = attributes_for(:customer)
+  #   attrs1 = attributes_for(:customer_vip)
+  #   attrs2 = attributes_for(:customer_default)
+  #   p attrs
+  #   p attrs1
+  #   p attrs2
+  #   customer = Customer.build(attrs)
+  #   expect(customer.full_name).to start_with("Sr.")
+  # end
+  it 'Usando o Attributos Transitórios' do
+    
+    customer = create(:customer, upcased: true)
+    
+    expect(customer.name).to eq(customer.name.upcase)
   end
 end


### PR DESCRIPTION
Criamos um atributo transitório em spec/factories/customer.rb onde o valor upcased pode ser mudado na criação do objeto. Ex: customer = create(:customer, upcased: true)

```ruby
transient do
      upcased  {false} 
    end
``` 

no final da factory criamos um after(:create) para executar verificações depois da criação:

```ruby
after(:create) do |customer, evaluator| 
      customer.name.upcase! if evaluator.upcased 
    end
``` 

Executa essa ação após criar o objeto e transforma em maiúsculo se `upcased == true.`

No teste spec/models/customer_spec.rb

```ruby
require 'rails_helper'

RSpec.describe Customer, type: :model do

   it 'Usando o Attributos Transitórios' do
    
    customer = create(:customer, upcased: true)
    
    expect(customer.name).to eq(customer.name.upcase)
  end
end
``` 

__OBS:__ Se usarmos o attrs = attributes_for(:customer) para pegar os atributos, ele não vai contemplar o atributo transitório.