### PR TITLE
feat: traits

### DIFF
--- a/db/migrate/20240301131925_create_customers.rb
+++ b/db/migrate/20240301131925_create_customers.rb
@@ -5,6 +5,7 @@ class CreateCustomers < ActiveRecord::Migration[7.1]
       t.string :email
       t.boolean :vip
       t.integer :days_to_pay
+      t.string :gender
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,6 +16,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_01_131925) do
     t.string "email"
     t.boolean "vip"
     t.integer "days_to_pay"
+    t.string "gender"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/factories/customer.rb
+++ b/spec/factories/customer.rb
@@ -5,23 +5,40 @@ FactoryBot.define do
       upcased  {false} #valor que pode ser mudado na criação do objeto - customer = create(:customer, upcased: true)
     end
 
-
     name {Faker::Name.name}
     email {"beatriz@filha.com"}
     
-    factory :customer_vip do
+    trait :male do
+      gender {'M'}
+    end
+    
+    trait :female do
+      gender {'F'}
+    end
+    
+    trait :vip do
       vip {true}
       days_to_pay {30}
     end
 
-    factory :customer_default do
+    trait :default do
       vip {false}
       days_to_pay {15}
     end
 
+    factory :customer_male, traits: [:male]
+    factory :customer_female, traits: [:female]
+    factory :customer_vip, traits: [:vip]
+    factory :customer_default, traits: [:default]
+    factory :customer_male_vip, traits: [:male, :vip]
+    factory :customer_female_vip, traits: [:female, :vip]
+    factory :customer_male_default, traits: [:male, :default]
+    factory :customer_female_default, traits: [:female, :default]
+
+
     after(:create) do |customer, evaluator|  #executa essa ação após criar o objeto.
       customer.name.upcase! if evaluator.upcased #transforma em maiusculo se upcased == true
-    end
+    end 
 
   end
 end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Customer, type: :model do
   #   expect(customer.full_name).to eq("Sr. Vanderlei Pinto")
   # end
 
-####  Creating using factory bot -------------------------
+####  Creating using factory bot -----------------------
 
   # it 'Full name' do 
   #   customer = build (:customer)
@@ -49,10 +49,24 @@ RSpec.describe Customer, type: :model do
   #   customer = Customer.build(attrs)
   #   expect(customer.full_name).to start_with("Sr.")
   # end
-  it 'Usando o Attributos Transitórios' do
+  # it 'Usando o Attributos Transitórios' do
     
-    customer = create(:customer, upcased: true)
+  #   customer = create(:customer, upcased: true)
     
-    expect(customer.name).to eq(customer.name.upcase)
+  #   expect(customer.name).to eq(customer.name.upcase)
+  # end
+
+  it 'Cliente masculino vip' do
+    customer = create(:customer_male_vip)
+    expect(customer.gender).to eq('M')
+    expect(customer.vip).to eq(true)
   end
+
+  it 'Cliente Feminino default' do
+    customer = create(:customer_female_default)
+    expect(customer.gender).to eq('F')
+    expect(customer.vip).to eq(false)
+  end
+
+  
 end


### PR DESCRIPTION
Para o uso do recurso traits, adicionaremos um campo gender ao model Customer pelo Migrations.

```ruby
class CreateCustomers < ActiveRecord::Migration[7.1]

  def change
    create_table :customers do |t|
      t.string :name
      t.string :email
      t.boolean :vip
      t.integer :days_to_pay
      t.string :gender
 
      t.timestamps
    end
  end
end
``` 


`rails db:drop db:create db:migrate`



Criemos duas factories para costumer:

```ruby
...
  factory :customer_male do
      gender {'M'}
    end
    
    factory :customer_female do
      gender {'F'}
    end
...
``` 
Testemos:

```ruby
it 'Cliente masculino' do
    customer = create(:customer_male)
    expect(customer.gender).to eq('M')
  end
``` 
Tudo certo, mas se quisermos um cliente feminino e vip?

Para isso usaremos, dentro da factory, um trait ao invés de factory feminino ou masculino, ficaria assim:

```ruby
   trait :customer_male do
      gender {'M'}
    end
    
    trait :customer_female do
      gender {'F'}
    end
``` 

O teste usando traits fica assim:
```ruby
  it 'Cliente masculino' do
    customer = create(:customer_vip, :male) #1º é o factory e :male o trait
    expect(customer.gender).to eq('M')
    expect(customer.vip).to eq(true)
  end

``` 
Agora podemos usar as traits para englobar todas as opções:

O arquivo spec/factories/customer.rb ficaria assim:
```ruby
FactoryBot.define do
  factory :customer, aliases: [:user, :worker] do
    
...
 
    name {Faker::Name.name}
    email {"beatriz@filha.com"}
    
    trait :male do
      gender {'M'}
    end
    
    trait :female do
      gender {'F'}
    end
    
    trait :vip do
      vip {true}
      days_to_pay {30}
    end
 
    trait :default do
      vip {false}
      days_to_pay {15}
    end
 
    factory :customer_male, traits: [:male]
    factory :customer_female, traits: [:female]
    factory :customer_vip, traits: [:vip]
    factory :customer_default, traits: [:default]
    factory :customer_male_vip, traits: [:male, :vip]
    factory :customer_female_vip, traits: [:female, :vip]
    factory :customer_male_default, traits: [:male, :default]
    factory :customer_female_default, traits: [:female, :default]
 
...
 
  end
end
``` 
Exemplo do teste:
```ruby
require 'rails_helper'
 
RSpec.describe Customer, type: :model do
 
   it 'Cliente masculino vip' do
    customer = create(:customer_male_vip)
    expect(customer.gender).to eq('M')
    expect(customer.vip).to eq(true)
  end
 
  it 'Cliente Feminino default' do
    customer = create(:customer_female_default)
    expect(customer.gender).to eq('F')
    expect(customer.vip).to eq(false)
  end  
end
``` 