### PR TITLE
feat:Associações (belongs_to)

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,3 @@
+class Order < ApplicationRecord
+  belongs_to :customer
+end

--- a/db/migrate/20240308204952_create_orders.rb
+++ b/db/migrate/20240308204952_create_orders.rb
@@ -1,0 +1,10 @@
+class CreateOrders < ActiveRecord::Migration[7.1]
+  def change
+    create_table :orders do |t|
+      t.string :description
+      t.references :customer, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_01_131925) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_08_204952) do
   create_table "customers", force: :cascade do |t|
     t.string "name"
     t.string "email"
@@ -21,4 +21,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_01_131925) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "orders", force: :cascade do |t|
+    t.string "description"
+    t.integer "customer_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["customer_id"], name: "index_orders_on_customer_id"
+  end
+
+  add_foreign_key "orders", "customers"
 end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :order do
+    sequence(:description) { |n| "Pedido #{n}" }
+    
+    #criando o customer automaticamente:
+    customer #cria o customer automaticamente para associar ao pedido
+    #equivalente a:
+    #association :customer, factory: :customer
+  end 
+end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -56,26 +56,28 @@ RSpec.describe Customer, type: :model do
   #   expect(customer.name).to eq(customer.name.upcase)
   # end
 
-  it 'Cliente masculino vip' do
-    customer = create(:customer_male_vip)
-    expect(customer.gender).to eq('M')
-    expect(customer.vip).to eq(true)
-  end
+  # it 'Cliente masculino vip' do
+  #   customer = create(:customer_male_vip)
+  #   expect(customer.gender).to eq('M')
+  #   expect(customer.vip).to eq(true)
+  # end
 
-  it 'Cliente Feminino default' do
-    customer = create(:customer_female_default)
-    expect(customer.gender).to eq('F')
-    expect(customer.vip).to eq(false)
-  end
+  # it 'Cliente Feminino default' do
+  #   customer = create(:customer_female_default)
+  #   expect(customer.gender).to eq('F')
+  #   expect(customer.vip).to eq(false)
+  # end
   
-  it 'Creates email using sequence' do
-    #in the factory the email sequence works like this:
-    # sequence(:email) {|n| "customer_email-#{n}@email.com"}
-    customer = create(:customer_female_default)
-    customer2 = create(:customer_male_default)
-    puts customer.email
-    puts customer2.email
-  end
+  # it 'Creates email using sequence' do
+  #   #in the factory the email sequence works like this:
+  #   # sequence(:email) {|n| "customer_email-#{n}@email.com"}
+  #   customer = create(:customer_female_default)
+  #   customer2 = create(:customer_male_default)
+  #   puts customer.email
+  #   puts customer2.email
+  # end
+
+
   
 end
  

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+  it 'Verifica se o order possui customer' do
+    order = create(:order)
+    expect(order.customer).to be_kind_of(Customer)
+  end
+
+  it 'Verifica se o order possui customer' do
+    customer_manual = crete(:customer_female_vip)
+    order = create(:order, customer: customer_manual) #sobrescrevendo o customer automático
+    expect(order.customer).to be_kind_of(Customer)
+  end
+
+end


### PR DESCRIPTION
Criaremos um novo model Orders que referencia ao Customer

`rails g model Order description:string customer:references`

Todo pedido pertence ao cliente.

O sistema vai criar uma Factory para Order automaticamente.

Na factory de order usaremos o sequence para sequenciar a descrição dos pedidos

```ruby
FactoryBot.define do
  factory :order do
    sequence(:description) { |n| "Pedido #{n}" }
    
    #criando o customer automaticamente:
    customer #cria o customer automaticamente para associar ao pedido
    #equivalente a:
    #association :customer, factory: :customer
  end 
end
``` 
Ao criar o pedido ele cria o customer por conta da associação.

No teste spec/models/order_spec.rb, verificaremos se o Customer foi criado automaticamente.

```ruby
RSpec.describe Order, type: :model do
  it 'Verifica se o order possui customer' do
    order = create(:order)
    expect(order.customer).to be_kind_of(Customer)
  end
end

``` 
Também podemos criar um customer dentro de order_spec.rb e ele sobrescrever.

```ruby
 it 'Verifica se o order possui customer' do
    customer_manual = crete(:customer_female_vip)
    order = create(:order, customer: customer_manual) #sobrescrevendo o customer automático
    expect(order.customer).to be_kind_of(Customer)
  end
``` 
