### PR TITLE
feat: has_many (rspec)

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,4 +1,5 @@
 class Customer < ApplicationRecord
+  has_many :orders
   def full_name
     "Sr. #{name}"
   end

--- a/spec/factories/customers.rb
+++ b/spec/factories/customers.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     
     transient do
       upcased  {false} #valor que pode ser mudado na criação do objeto - customer = create(:customer, upcased: true)
+      qtt_orders {3}
     end
 
     name {Faker::Name.name}
@@ -28,6 +29,14 @@ FactoryBot.define do
       days_to_pay {15}
     end
 
+    trait :with_orders do
+      after(:create) do |customer, evaluator|  #executa essa ação após criar o objeto.
+        create_list(:order, evaluator.qtt_orders, customer: customer)
+      end 
+    end
+
+    
+    factory :customer_with_orders, traits: [:with_orders]
     factory :customer_male, traits: [:male]
     factory :customer_female, traits: [:female]
     factory :customer_vip, traits: [:vip]
@@ -40,7 +49,6 @@ FactoryBot.define do
 
     after(:create) do |customer, evaluator|  #executa essa ação após criar o objeto.
       customer.name.upcase! if evaluator.upcased #transforma em maiusculo se upcased == true
-    end 
-
+    end  
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -6,17 +6,24 @@ RSpec.describe Order, type: :model do
     expect(order.customer).to be_kind_of(Customer)
   end
 
-  it 'Verifica se o order possui customer' do
+  it 'Verifica se o order possui customer (belongs_to)' do
     customer_manual = create(:customer_female_vip)
     order = create(:order, customer: customer_manual) #sobrescrevendo o customer automático
     expect(order.customer).to be_kind_of(Customer)
-  end
+  end  
 
-  it 'tem 3 pedidos' do
+  it 'tem 3 pedidos (create_list)' do
     orders = create_list(:order, 3, description: "Testeee")
     p orders.inspect
     expect(orders.count).to eq(3)
   end
 
+  it 'has_many' do
+    customer = create(:customer, :with_orders, qtt_orders: 10) #sobrescreve as orders
+    customer2 = create(:customer_with_orders) #já cria com as 3 ordens padrão
+    puts customer.inspect
+    puts customer.orders.inspect
+    expect(customer.orders.count).to eq(10)
+  end
 
 end 


### PR DESCRIPTION
[Video](https://www.udemy.com/course/rails-tdd/learn/lecture/8525656#notes)

Para esta aula vamos adicionar `has_many :orders` ao model Customer

```ruby
class Customer < ApplicationRecord
  has_many :orders
  def full_name
    "Sr. #{name}"
  end
end
``` 
Na factory criaremos mais um atribuno no transient chamado qtt_orders 3 (quantidade de orders 3)

```ruby
   transient do
      upcased  {false} #valor que pode ser mudado na criação do objeto - customer = create(:customer, upcased: true)
      qtt_orders {3}
    end

``` 

E faremos um trait com um callback para criar uma lista de orders e inserir o transient no customer criado.

```ruby
    trait :with_orders do
      after(:create) do |customer, evaluator|  
        create_list(:order, evaluator.qtt_orders, customer: customer)
      end 
    end

``` 

No teste fica assim:
```ruby

  it 'has_many' do
    customer = create(:customer, :with_orders)
    puts customer.inspect
    puts customer.orders.inspect
    expect(customer.orders.count).to eq(3)
  end

``` 

também podemos sobrescrever a quantidade de orders:

```ruby
customer = create(:customer, :with_orders, qtt_orders:15)
...
expect(customer.orders.count).to eq(15)
``` 

Também podemos criar um factory padrão de custumer_with_order:

```ruby
factory :customer_with_orders, traits: [:with_orders]
``` 
E no teste fica assim:

```ruby
customer2 = create(:customer_with_orders) #já cria com as 3 ordens padrão
``` 