### PR TITLE
feat: Factorybot Lint

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,5 +1,8 @@
 class Customer < ApplicationRecord
   has_many :orders
+
+  validates :address, presence:true
+
   def full_name
     "Sr. #{name}"
   end

--- a/db/migrate/20240301131925_create_customers.rb
+++ b/db/migrate/20240301131925_create_customers.rb
@@ -6,6 +6,7 @@ class CreateCustomers < ActiveRecord::Migration[7.1]
       t.boolean :vip
       t.integer :days_to_pay
       t.string :gender
+      t.string :address
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,6 +17,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_08_204952) do
     t.boolean "vip"
     t.integer "days_to_pay"
     t.string "gender"
+    t.string "address"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/factories/customers.rb
+++ b/spec/factories/customers.rb
@@ -7,7 +7,10 @@ FactoryBot.define do
     end
 
     name {Faker::Name.name}
+    #address {Faker::Address.street_address}
     #email {"beatriz@filha.com"}  #comentado para uso do sequence
+
+    
 
     sequence(:email, 'January') {|n| "meu_email-#{n}@email.com"}
     

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -39,43 +39,46 @@ RSpec.describe Customer, type: :model do
   #   expect(customer.vip).to eq(true)
   #  end
 
-  # it 'Usando o Attributes_for' do
-  #   attrs = attributes_for(:customer)
-  #   attrs1 = attributes_for(:customer_vip)
-  #   attrs2 = attributes_for(:customer_default)
-  #   p attrs
-  #   p attrs1
-  #   p attrs2
-  #   customer = Customer.build(attrs)
-  #   expect(customer.full_name).to start_with("Sr.")
-  # end
-  # it 'Usando o Attributos Transitórios' do
-    
-  #   customer = create(:customer, upcased: true)
-    
-  #   expect(customer.name).to eq(customer.name.upcase)
-  # end
+  it 'Usando o Attributes_for' do
+    attrs = attributes_for(:customer)
+    attrs1 = attributes_for(:customer_vip)
+    attrs2 = attributes_for(:customer_default)
+    p attrs
+    p attrs1
+    p attrs2
+    customer = Customer.build(attrs)
+    p "Attributes for -> #{customer.inspect}"
+    expect(customer.full_name).to start_with("Sr.")
+  end
 
-  # it 'Cliente masculino vip' do
-  #   customer = create(:customer_male_vip)
-  #   expect(customer.gender).to eq('M')
-  #   expect(customer.vip).to eq(true)
-  # end
 
-  # it 'Cliente Feminino default' do
-  #   customer = create(:customer_female_default)
-  #   expect(customer.gender).to eq('F')
-  #   expect(customer.vip).to eq(false)
-  # end
+  it 'Usando o Attributos Transitórios' do
+    
+    customer = create(:customer, upcased: true)
+    
+    expect(customer.name).to eq(customer.name.upcase)
+  end
+
+  it 'Cliente masculino vip' do
+    customer = create(:customer_male_vip)
+    expect(customer.gender).to eq('M')
+    expect(customer.vip).to eq(true)
+  end
+
+  it 'Cliente Feminino default' do
+    customer = create(:customer_female_default)
+    expect(customer.gender).to eq('F')
+    expect(customer.vip).to eq(false)
+  end
   
-  # it 'Creates email using sequence' do
-  #   #in the factory the email sequence works like this:
-  #   # sequence(:email) {|n| "customer_email-#{n}@email.com"}
-  #   customer = create(:customer_female_default)
-  #   customer2 = create(:customer_male_default)
-  #   puts customer.email
-  #   puts customer2.email
-  # end
+  it 'Creates email using sequence' do
+    #in the factory the email sequence works like this:
+    # sequence(:email) {|n| "customer_email-#{n}@email.com"}
+    customer = create(:customer_female_default)
+    customer2 = create(:customer_male_default)
+    puts customer.email
+    puts customer2.email
+  end
 
 
   

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -18,12 +18,27 @@ RSpec.describe Order, type: :model do
     expect(orders.count).to eq(3)
   end
 
+  it 'tem 2 pedidos (create_pair)' do
+    orders = create_pair(:order, description: "Testeee de pair")    
+    expect(orders.count).to eq(2)
+  end
+
   it 'has_many' do
     customer = create(:customer, :with_orders, qtt_orders: 10) #sobrescreve as orders
     customer2 = create(:customer_with_orders) #já cria com as 3 ordens padrão
-    puts customer.inspect
-    puts customer.orders.inspect
+    puts customer.inspect 
+    #puts customer.orders.inspect
     expect(customer.orders.count).to eq(10)
   end
+
+  it 'build_stubbed' do
+    customer = build_stubbed(:customer, :with_orders, qtt_orders: 10) #sobrescreve as orders
+    customer2 = create(:customer_with_orders) #já cria com as 3 ordens padrão
+    puts customer.inspect 
+    #puts customer.orders.inspect
+    expect(true).to eq(true)
+  end
+
+  
 
 end 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,11 @@ RSpec.configure do |config|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
 
+  #FactoryBot Lint
+  config.before(:suite) do #antes de tudo, verifica se está faltando alguma coisa nos models.
+    FactoryBot.lint
+  end
+
   # rspec-mocks config goes here. You can use an alternate test double
   # library (such as bogus or mocha) by changing the `mock_with` option here.
   config.mock_with :rspec do |mocks|


### PR DESCRIPTION
Para usar esse artifício, criaremos um novo campo no migrations de Customers.
```ruby
class CreateCustomers < ActiveRecord::Migration[7.1]
  def change
    create_table :customers do |t|
      t.string :name
      t.string :email
      t.boolean :vip
      t.integer :days_to_pay
      t.string :gender
      t.string :adress
 
      t.timestamps
    end
  end
end
``` 

Agora faremos com que esse campo seja obrigatório em app/models/customer.rb
```ruby
class Customer < ApplicationRecord
  has_many :orders
 
  validates :address, presence:true
 
  def full_name
    "Sr. #{name}"
  end
end
``` 
Reconfigurando o banco de dados.

`rails db:drop db:create db:migrate`

O testes feitos no rspec dependem muito dos campos que existem ou deixem de existir.

Então se fizermos os testes depois de adicionar address.

Adicionando um faker adress: spec/factories/customers.rb

```ruby
address {Faker::Address.street_address}
``` 
O factorybot lint verifica as validações dos testes e avisa quando ocorre.

Para isso devem ser feitas alterações no arquivo spec/spec_helper.rb

```ruby
RSpec.configure do |config|
...
config.before(:suite) do #verifica se está faltando alguma coisa nos models.
      FactoryBot.lint
    end
...
end
``` 
Dessa maneira se ocorrer o erro de faltar algum campo do model ele vai explicitar de uma maneira mais legível.

__Exemplo de erro__

Exemplo do erro quando suprimimos o campo address (`#address {Faker::Address.street_address}`)
```shell
An error occurred in a `before(:suite)` hook.
Failure/Error: FactoryBot.lint
 
FactoryBot::InvalidFactoryError:
  The following factories are invalid:
 
  * customer - Validation failed: Address can't be blank (ActiveRecord::RecordInvalid)
  * customer_with_orders - Validation failed: Address can't be blank (ActiveRecord::RecordInvalid)
  * customer_male - Validation failed: Address can't be blank (ActiveRecord::RecordInvalid)
  * customer_female - Validation failed: Address can't be blank (ActiveRecord::RecordInvalid)
  * customer_vip - Validation failed: Address can't be blank (ActiveRecord::RecordInvalid)
  * customer_default - Validation failed: Address can't be blank (ActiveRecord::RecordInvalid)
...
 
# ./spec/spec_helper.rb:33:in `block (2 levels) in <main>'
# -e:1:in `<main>'
 
Finished in 0.23674 seconds (files took 0.17039 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples
``` 