### PR TITLE
feat: httparty

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ group :development, :test do
   gem 'capybara'
   gem 'factory_bot_rails'
   gem 'faker'
+  gem 'httparty'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,9 @@ GEM
       i18n (>= 1.8.11, < 2)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.0.1)
@@ -137,6 +140,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.22.2)
     msgpack (1.7.2)
+    multi_xml (0.6.0)
     mutex_m (0.2.0)
     net-imap (0.4.10)
       date
@@ -280,6 +284,7 @@ DEPENDENCIES
   debug
   factory_bot_rails
   faker
+  httparty
   importmap-rails
   jbuilder
   puma (>= 5.0)

--- a/spec/factories/customers.rb
+++ b/spec/factories/customers.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     end
 
     name {Faker::Name.name}
-    #address {Faker::Address.street_address}
+    address {Faker::Address.street_address}
     #email {"beatriz@filha.com"}  #comentado para uso do sequence
 
     

--- a/spec/httparty/httparty_spec.rb
+++ b/spec/httparty/httparty_spec.rb
@@ -1,0 +1,10 @@
+describe 'HTTParty' do
+
+  it 'HTTParty' do
+    response = HTTParty.get('http://jsonplaceholder.typicode.com/posts/2')
+    content_type = response.headers["content-type"]
+
+    expect(content_type).to match(/application\/json/)
+  end
+
+end


### PR DESCRIPTION
Instalação no arquivo Gemfile

`gem 'httparty'`

Vamos criar um arquivo de teste: spec/httparty/httparty_spec.rb

```ruby
describe 'HTTParty' do
 
  it 'HTTParty' do
    response = HTTParty.get('http://jsonplaceholder.typicode.com/posts/2')
    content_type = response.headers["content-type"]
 
    expect(content_type).to match(/application\/json/)
  end
 
end
``` 
Aqui ele faz uma requisição, recebe uma resposta e verificamos no header se o content-type corresponde a 'aplication/json'.